### PR TITLE
feat: group non-major updates by manager instead of all-in-one

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,6 @@
     "npm:unpublishSafe",
     "packages:linters",
     "packages:jsTest",
-    "group:allNonMajor",
     "replacements:all",
     "helpers:pinGitHubActionDigests",
     ":pinVersions",
@@ -20,6 +19,10 @@
   "platformAutomerge": true,
   "labels": ["renovate", "renovate/{{depName}}"],
   "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major {{manager}} dependencies"
+    },
     {
       "matchPackageNames": ["pnpm"],
       "automerge": true


### PR DESCRIPTION
group:allNonMajor は gha/npm/rust/docker などカテゴリの異なる 依存をすべて1つの PR にまとめてしまい、レビュー単位が大きすぎた。
マネージャー単位でグルーピングすることで、カテゴリごとに
non-major 更新をまとめた PR を作れるようにする。